### PR TITLE
fix(source-aws): correct parameter order for writeTest

### DIFF
--- a/packages/source-aws/tsconfig.json
+++ b/packages/source-aws/tsconfig.json
@@ -6,5 +6,5 @@
     "lib": ["es2018", "dom"]
   },
   "include": ["src/**/*"],
-  "references": [{ "path": "../core" }]
+  "references": [{ "path": "../core" }, { "path": "../source-memory" }]
 }


### PR DESCRIPTION
- fix(source-aws): correct parameter order for writeTest
- refactor: use actual streams
