### PR TITLE
feat(fs-aws): add credential config for public and requester pays

### DIFF
--- a/packages/fs-aws/src/__tests__/credentials.test.ts
+++ b/packages/fs-aws/src/__tests__/credentials.test.ts
@@ -22,10 +22,16 @@ describe('AwsS3CredentialProvider', () => {
     assert.ok(fs.requestPayer === 'requester');
   });
 
-  it('should require a roleArn', () => {
+  it('should support requester pays from the current role', () => {
     const creds = new AwsS3CredentialProvider();
 
+    const fs = creds.createFileSystem({ ...baseConfig, roleArn: undefined, access: 'requesterPays' });
+    assert.ok(fs.s3 !== getPublicS3());
+    assert.ok(fs.requestPayer === 'requester');
+  });
+
+  it('should require a roleArn', () => {
+    const creds = new AwsS3CredentialProvider();
     assert.throws(() => creds.createFileSystem({ ...baseConfig }));
-    assert.throws(() => creds.createFileSystem({ ...baseConfig, access: 'requesterPays' }));
   });
 });

--- a/packages/fs-aws/src/__tests__/credentials.test.ts
+++ b/packages/fs-aws/src/__tests__/credentials.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { AwsS3CredentialProvider, getPublicS3 } from '../credentials.js';
+import { AwsCredentialConfig } from '../types.js';
+
+describe('AwsS3CredentialProvider', () => {
+  const baseConfig: AwsCredentialConfig = { type: 's3', prefix: 's3://' };
+  it('should set requester pays', () => {
+    const creds = new AwsS3CredentialProvider();
+
+    const fs = creds.createFileSystem({ ...baseConfig, access: 'public' });
+    assert.ok(fs.s3 === getPublicS3());
+    assert.ok(fs.requestPayer === 'public');
+  });
+
+  it('should support requester pays', () => {
+    const creds = new AwsS3CredentialProvider();
+
+    const fs = creds.createFileSystem({ ...baseConfig, roleArn: 'arn:...', access: 'requesterPays' });
+    assert.ok(fs.s3 !== getPublicS3());
+    assert.ok(fs.requestPayer === 'requester');
+  });
+
+  it('should require a roleArn', () => {
+    const creds = new AwsS3CredentialProvider();
+
+    assert.throws(() => creds.createFileSystem({ ...baseConfig }));
+    assert.throws(() => creds.createFileSystem({ ...baseConfig, access: 'requesterPays' }));
+  });
+});

--- a/packages/fs-aws/src/credentials.ts
+++ b/packages/fs-aws/src/credentials.ts
@@ -79,6 +79,13 @@ export class AwsS3CredentialProvider implements FileSystemProvider<FsAwsS3> {
       return fs;
     }
 
+    // Requester pays off the current credentials
+    if (cs.access === 'requesterPays' && cs.roleArn == null) {
+      const fs = new FsAwsS3(new S3Client({}));
+      if (cs.access === 'requesterPays') fs.requestPayer = 'requester';
+      return fs;
+    }
+
     // All other credentials need a role assumed
     if (cs.roleArn == null) throw new Error('No roleArn is defined for prefix: ' + cs.prefix);
     const client = new S3Client({

--- a/packages/fs-aws/src/fs.s3.ts
+++ b/packages/fs-aws/src/fs.s3.ts
@@ -1,3 +1,6 @@
+import type { Readable } from 'node:stream';
+import { PassThrough } from 'node:stream';
+
 import {
   DeleteObjectCommand,
   GetObjectCommand,
@@ -7,10 +10,9 @@ import {
   S3Client,
 } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
-import { FileInfo, FileSystem, FileSystemAction, FsError, ListOptions, WriteOptions, isRecord } from '@chunkd/fs';
+import { FileInfo, FileSystem, FileSystemAction, FsError, isRecord, ListOptions, WriteOptions } from '@chunkd/fs';
 import { SourceAwsS3 } from '@chunkd/source-aws';
-import type { Readable } from 'node:stream';
-import { PassThrough } from 'node:stream';
+
 import { AwsS3CredentialProvider } from './credentials.js';
 
 function isReadable(r: any): r is Readable {
@@ -49,7 +51,7 @@ export class FsAwsS3 implements FileSystem {
   writeTests = new Map<string, Promise<void | FsAwsS3>>();
 
   /** Request Payment option */
-  requestPayer?: 'requester';
+  requestPayer?: 'requester' | 'public';
 
   /**
    * When testing write permissions add a suffix to the file name, this file will be deleted up after writing completes

--- a/packages/fs-aws/src/types.ts
+++ b/packages/fs-aws/src/types.ts
@@ -1,20 +1,53 @@
 export interface AwsCredentialConfig {
-  /** Prefix type generally s3 */
+  /**
+   * Prefix type generally s3
+   */
   type: 's3';
-  /** Prefix should always start with `s3://${bucket}` */
+
+  /**
+   * Location that these credentials are valid for,
+   *
+   * prefixes should always start with `s3://${bucket}/`
+   *
+   * @example
+   * ```typescript
+   * "s3://example/" // Matches all files in "s3://example/**"
+   * "s3://example"  // Matches all files in all buckets starting with "s3://example*"
+   * ```
+   */
   prefix: string;
-  /** Role to use to access */
-  roleArn: string;
-  /** Aws account this bucket belongs to */
+
+  /**
+   * Role to use to access
+   *
+   * roleArn is not required if access is "public"
+   */
+  roleArn?: string;
+
+  /**
+   * Aws account this bucket belongs to
+   */
   accountId?: string;
-  /** Bucket name */
-  bucket?: string;
-  /** ExternalId if required */
+
+  /**
+   * ExternalId if required
+   */
   externalId?: string;
-  /** Max role session duration */
+
+  /**
+   * Max role session duration
+   */
   roleSessionDuration?: number;
-  /** Can these credentials be used for "read" or "read-write" access */
+
+  /**
+   * Can these credentials be used for "read" or "read-write" access
+   */
   flags?: 'r' | 'rw';
+
+  /**
+   * Can this prefix be accessed without credentials or as requesterPays
+   */
+  access?: 'public' | 'requesterPays';
 }
 
 export interface AwsCredentialProvider {


### PR DESCRIPTION
#### Motivation

Requester pays and public buckets are pretty common ways of accessing s3 locations, access needs to be configured so that a bucket can be accessed 

with either:

- "assume this role then use requester pays"
- "use the current role but as requester pays"

or as a public bucket with no credentials.

#### Modification

allow credentials to be defined as requester pays or public
