### PR TITLE
fix(source-aws): prevent s3 client from being logged when errors are thrown

### DIFF
--- a/packages/source-aws/src/__test__/source.aws.test.ts
+++ b/packages/source-aws/src/__test__/source.aws.test.ts
@@ -7,4 +7,9 @@ describe('SourceAwsS3', () => {
   it('should create s3 links from string url', () => {
     assert.equal(new SourceAwsS3('s3://foo/bar.txt').url.href, 's3://foo/bar.txt');
   });
+
+  it('should not expose "client" for logging', () => {
+    const keys = Object.keys(new SourceAwsS3('s3://foo/bar.txt'));
+    assert.equal(keys.includes('client'), false);
+  });
 });

--- a/packages/source-aws/src/__test__/source.aws.test.ts
+++ b/packages/source-aws/src/__test__/source.aws.test.ts
@@ -9,7 +9,9 @@ describe('SourceAwsS3', () => {
   });
 
   it('should not expose "client" for logging', () => {
-    const keys = Object.keys(new SourceAwsS3('s3://foo/bar.txt'));
+    const source = new SourceAwsS3('s3://foo/bar.txt');
+    const keys = Object.keys(source);
     assert.equal(keys.includes('client'), false);
+    assert.notEqual(source.client.config, null);
   });
 });

--- a/packages/source-aws/src/index.ts
+++ b/packages/source-aws/src/index.ts
@@ -51,13 +51,9 @@ export class SourceAwsS3 implements Source {
 
   constructor(url: URL | string, client: S3Client = new S3Client({})) {
     this.url = typeof url === 'string' ? new URL(url) : url;
-    // Make typescript happy
+    // S3 clients are very large and if this object gets logged the log is very very large
+    Object.defineProperty(this, 'client', { enumerable: false });
     this.client = client;
-    // S3 clients are very large and if this object gets logged the client is very very large
-    Object.defineProperty(this, 'client', {
-      enumerable: false,
-      value: client,
-    });
   }
 
   _head?: Promise<SourceMetadata>;

--- a/packages/source-aws/src/index.ts
+++ b/packages/source-aws/src/index.ts
@@ -51,7 +51,13 @@ export class SourceAwsS3 implements Source {
 
   constructor(url: URL | string, client: S3Client = new S3Client({})) {
     this.url = typeof url === 'string' ? new URL(url) : url;
+    // Make typescript happy
     this.client = client;
+    // S3 clients are very large and if this object gets logged the client is very very large
+    Object.defineProperty(this, 'client', {
+      enumerable: false,
+      value: client,
+    });
   }
 
   _head?: Promise<SourceMetadata>;


### PR DESCRIPTION
### Motivation

The `source` object is thrown when errors happen such as when a read fails. If this error is logged then the `soruce.client` is also logged and logging the entire S3 client is huge.

### Modification

Prevent the S3 object from being visible for loggers

