### PR TITLE
feat: expose raw response object from .head and .details

### DIFF
--- a/packages/fs-aws/src/fs.s3.ts
+++ b/packages/fs-aws/src/fs.s3.ts
@@ -105,20 +105,24 @@ export class FsAwsS3 implements FileSystem {
         if (res.CommonPrefixes != null) {
           for (const prefix of res.CommonPrefixes) {
             if (prefix.Prefix == null) continue;
-            yield { url: new URL(`s3://${Bucket}/${prefix.Prefix}`), isDirectory: true, $response: null };
+            const info = { url: new URL(`s3://${Bucket}/${prefix.Prefix}`), isDirectory: true, $response: null };
+            Object.defineProperty(info, '$response', { enumerable: false });
+            yield info;
           }
         }
 
         if (res.Contents != null) {
           for (const obj of res.Contents) {
             if (obj.Key == null) continue;
-            yield {
+            const info = {
               url: new URL(`s3://${Bucket}/${obj.Key}`),
               size: obj.Size,
               eTag: obj.ETag,
               lastModified: obj.LastModified?.toISOString(),
               $response: obj,
             };
+            Object.defineProperty(info, '$response', { enumerable: false });
+            yield info;
           }
         }
 
@@ -295,6 +299,7 @@ export class FsAwsS3 implements FileSystem {
       if (res.ContentType) info.contentType = res.ContentType;
       if (res.ETag) info.eTag = res.ETag;
       if (res.LastModified) info.lastModified = res.LastModified.toISOString();
+      Object.defineProperty(info, '$response', { enumerable: false });
 
       return info;
     } catch (e) {
@@ -309,5 +314,9 @@ export class FsAwsS3 implements FileSystem {
       }
       throw ce;
     }
+  }
+
+  static is(fs: FileSystem): fs is FsAwsS3 {
+    return fs instanceof FsAwsS3 || fs.name === 's3';
   }
 }

--- a/packages/fs/src/file.system.ts
+++ b/packages/fs/src/file.system.ts
@@ -4,7 +4,7 @@ import { Source } from '@chunkd/source';
 
 export type FileWriteTypes = Buffer | Readable | string;
 
-export interface FileInfo {
+export interface FileInfo<T = unknown> {
   /** file path */
   url: URL;
   /**
@@ -24,6 +24,12 @@ export interface FileInfo {
   eTag?: string;
   /** ISO String of when the file was last modified */
   lastModified?: string;
+
+  /**
+   * Raw response object
+   * For example in AWS S3 this is the HeadObjectResponse when doing head requests
+   */
+  $response?: T;
 }
 
 export interface WriteOptions {

--- a/packages/fs/src/systems/__test__/file.test.ts
+++ b/packages/fs/src/systems/__test__/file.test.ts
@@ -71,6 +71,16 @@ describe('LocalFileSystem', () => {
     }
   });
 
+  it('should head a file with details', async () => {
+    const ref = await fs.head(new URL('file.test.js', import.meta.url));
+
+    console.log(JSON.stringify(ref));
+
+    // response objects should be hidden
+    assert.ok(!JSON.stringify(ref).includes('$response'));
+    assert.ok(ref?.$response?.atime);
+  });
+
   it('should head/exists a file', async () => {
     const ref = await fs.head(new URL('file.test.js', import.meta.url));
     assert.notEqual(ref, null);

--- a/packages/fs/src/systems/file.ts
+++ b/packages/fs/src/systems/file.ts
@@ -88,7 +88,9 @@ export class FsFile implements FileSystem {
   async head(loc: URL): Promise<FileInfo<fs.Stats> | null> {
     try {
       const stat = await fs.promises.stat(loc);
-      return { url: loc, size: stat.size, isDirectory: stat.isDirectory(), $response: stat };
+      const info = { url: loc, size: stat.size, isDirectory: stat.isDirectory(), $response: stat };
+      Object.defineProperty(info, '$response', { enumerable: false });
+      return info;
     } catch (e) {
       if (isRecord(e) && e.code === 'ENOENT') return null;
       throw new FsError(`Failed to stat ${loc.href}`, getCode(e), loc, 'head', this, e);

--- a/packages/fs/src/systems/file.ts
+++ b/packages/fs/src/systems/file.ts
@@ -77,7 +77,7 @@ export class FsFile implements FileSystem {
     }
   }
 
-  async *details(loc: URL, opts?: ListOptions): AsyncGenerator<FileInfo & { isDirectory: boolean }> {
+  async *details(loc: URL, opts?: ListOptions): AsyncGenerator<FileInfo<fs.Stats>> {
     for await (const file of this.list(loc, opts)) {
       const res = await this.head(file);
       if (res == null) continue;
@@ -85,10 +85,10 @@ export class FsFile implements FileSystem {
     }
   }
 
-  async head(loc: URL): Promise<(FileInfo & { isDirectory: boolean }) | null> {
+  async head(loc: URL): Promise<FileInfo<fs.Stats> | null> {
     try {
       const stat = await fs.promises.stat(loc);
-      return { url: loc, size: stat.size, isDirectory: stat.isDirectory() };
+      return { url: loc, size: stat.size, isDirectory: stat.isDirectory(), $response: stat };
     } catch (e) {
       if (isRecord(e) && e.code === 'ENOENT') return null;
       throw new FsError(`Failed to stat ${loc.href}`, getCode(e), loc, 'head', this, e);

--- a/packages/fs/src/systems/http.ts
+++ b/packages/fs/src/systems/http.ts
@@ -28,7 +28,9 @@ export class FsHttp implements FileSystem {
       if (!res.ok) {
         throw new FsError(`Failed to head: ${loc.href}`, res.status, loc, 'read', this, new Error(res.statusText));
       }
-      return { url: loc, size: Number(res.headers.get('content-length')), isDirectory: false, $response: res };
+      const info = { url: loc, size: Number(res.headers.get('content-length')), isDirectory: false, $response: res };
+      Object.defineProperty(info, '$response', { enumerable: false });
+      return info;
     } catch (e) {
       if (FsError.is(e) && e.system === this) throw e;
       throw new FsError(`Failed to head: ${loc.href}`, 500, loc, 'read', this, e);

--- a/packages/fs/src/systems/http.ts
+++ b/packages/fs/src/systems/http.ts
@@ -2,7 +2,7 @@ import type { Readable } from 'node:stream';
 import { PassThrough, Stream } from 'node:stream';
 import type { ReadableStream } from 'node:stream/web';
 
-import { SourceHttp } from '@chunkd/source-http';
+import { FetchLikeResponse, SourceHttp } from '@chunkd/source-http';
 
 import { FsError } from '../error.js';
 import { FileInfo, FileSystem } from '../file.system.js';
@@ -22,13 +22,13 @@ export class FsHttp implements FileSystem {
     throw new FsError(`NotImplemented to details: ${loc.href}`, 500, loc, 'list', this);
   }
 
-  async head(loc: URL): Promise<(FileInfo & { isDirectory: boolean }) | null> {
+  async head(loc: URL): Promise<FileInfo<FetchLikeResponse> | null> {
     try {
       const res = await SourceHttp.fetch(loc, { method: 'HEAD' });
       if (!res.ok) {
         throw new FsError(`Failed to head: ${loc.href}`, res.status, loc, 'read', this, new Error(res.statusText));
       }
-      return { url: loc, size: Number(res.headers.get('content-length')), isDirectory: false };
+      return { url: loc, size: Number(res.headers.get('content-length')), isDirectory: false, $response: res };
     } catch (e) {
       if (FsError.is(e) && e.system === this) throw e;
       throw new FsError(`Failed to head: ${loc.href}`, 500, loc, 'read', this, e);

--- a/packages/fs/src/systems/memory.ts
+++ b/packages/fs/src/systems/memory.ts
@@ -76,7 +76,9 @@ export class FsMemory implements FileSystem {
     for await (const file of this.list(loc, opt)) {
       const data = await this.head(file);
       if (data == null) {
-        yield { url: file, isDirectory: true, $response: null };
+        const info = { url: file, isDirectory: true, $response: null };
+        Object.defineProperty(info, '$response', { enumerable: false });
+        yield info;
       } else {
         yield data;
       }
@@ -91,14 +93,16 @@ export class FsMemory implements FileSystem {
   head(loc: URL): Promise<FileInfo | null> {
     const obj = this.files.get(loc.href);
     if (obj == null) return Promise.resolve(null);
-    return Promise.resolve({
+    const info = {
       url: loc,
       size: obj.buffer.length,
       metadata: obj.opts?.metadata,
       contentType: obj.opts?.contentType,
       contentEncoding: obj.opts?.contentEncoding,
       $response: null,
-    });
+    };
+    Object.defineProperty(info, '$response', { enumerable: false });
+    return Promise.resolve(info);
   }
 
   delete(loc: URL): Promise<void> {

--- a/packages/fs/src/systems/memory.ts
+++ b/packages/fs/src/systems/memory.ts
@@ -76,7 +76,7 @@ export class FsMemory implements FileSystem {
     for await (const file of this.list(loc, opt)) {
       const data = await this.head(file);
       if (data == null) {
-        yield { url: file, isDirectory: true };
+        yield { url: file, isDirectory: true, $response: null };
       } else {
         yield data;
       }
@@ -97,6 +97,7 @@ export class FsMemory implements FileSystem {
       metadata: obj.opts?.metadata,
       contentType: obj.opts?.contentType,
       contentEncoding: obj.opts?.contentEncoding,
+      $response: null,
     });
   }
 


### PR DESCRIPTION
### Motivation

There are a lot of options being added to S3 response objects that are useful to the consumer it is far too hard to keep upto date with which specific fields are useful to have.

### Modification

Expose the raw response objects from `.details` and `.head` requests