### PR TITLE
fix: forward abort signal to middleware and chunked requests

### DIFF
--- a/packages/middleware/src/middleware/__test__/chunk.test.ts
+++ b/packages/middleware/src/middleware/__test__/chunk.test.ts
@@ -32,6 +32,18 @@ describe('SourceChunk', () => {
     assert.deepEqual(spy.mock.calls[1].arguments, [4, 4, undefined]);
   });
 
+  it('should forward the abort signal to chunked requests', async (t) => {
+    const source = new SourceMemory('memory://test.json', Buffer.from(JSON.stringify({ hello: 'world' })));
+    const view = new SourceView(source, [new SourceChunk({ size: 4 })]);
+    const spy = t.mock.method(source, 'fetch');
+    const controller = new AbortController();
+
+    await view.fetch(0, 8, { signal: controller.signal });
+    assert.equal(spy.mock.callCount(), 2);
+    assert.deepEqual(spy.mock.calls[0].arguments, [0, 4, { signal: controller.signal }]);
+    assert.deepEqual(spy.mock.calls[1].arguments, [4, 4, { signal: controller.signal }]);
+  });
+
   it('should end at the size of the file', async () => {
     const dataTest = JSON.stringify({ hello: 'world', data: Buffer.alloc(16).toString('base64') });
     const source = new SourceMemory('memory://test.json', Buffer.from(dataTest));

--- a/packages/middleware/src/middleware/chunk.ts
+++ b/packages/middleware/src/middleware/chunk.ts
@@ -71,7 +71,9 @@ export class SourceChunk implements SourceMiddleware {
       const startByte = chunk * this.chunkSize;
       const endByte = Math.min(startByte + this.chunkSize, maxEndByte);
       const chunkLength = endByte - startByte;
-      promises.push(req.source.fetch(chunk * this.chunkSize, chunkLength));
+      promises.push(
+        req.source.fetch(chunk * this.chunkSize, chunkLength, req.signal ? { signal: req.signal } : undefined),
+      );
     }
 
     const results = await Promise.all(promises);

--- a/packages/source/src/__test__/view.test.ts
+++ b/packages/source/src/__test__/view.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { SourceMiddleware } from '../middleware.js';
+import type { Source } from '../source.js';
+import { SourceView } from '../view.js';
+
+function createTestSource(): Source {
+  return {
+    type: 'test',
+    url: new URL('memory://test'),
+    head() {
+      return Promise.resolve({});
+    },
+    fetch(_offset: number, length?: number) {
+      return Promise.resolve(new Uint8Array(length ?? 0).buffer);
+    },
+  };
+}
+
+function recordSignals(seen: (AbortSignal | undefined)[]): SourceMiddleware {
+  return {
+    name: 'recorder',
+    fetch(req, next) {
+      seen.push(req.signal);
+      return next(req);
+    },
+  };
+}
+
+describe('SourceView', () => {
+  it('should forward the abort signal to middleware', async () => {
+    const seen: (AbortSignal | undefined)[] = [];
+    const view = new SourceView(createTestSource(), [recordSignals(seen)]);
+    const controller = new AbortController();
+
+    await view.fetch(0, 4, { signal: controller.signal });
+    assert.equal(seen[0], controller.signal);
+  });
+
+  it('should pass undefined to middleware when no signal is given', async () => {
+    const seen: (AbortSignal | undefined)[] = [];
+    const view = new SourceView(createTestSource(), [recordSignals(seen)]);
+
+    await view.fetch(0, 4);
+    assert.equal(seen[0], undefined);
+  });
+});

--- a/packages/source/src/view.ts
+++ b/packages/source/src/view.ts
@@ -59,6 +59,6 @@ export class SourceView implements Source {
     }
 
     for (let i = middleware.length - 1; i >= 0; i--) handler = runMiddleware(middleware[i], handler);
-    return handler({ source: this, offset, length });
+    return handler({ source: this, offset, length, signal: options?.signal });
   }
 }


### PR DESCRIPTION
Fix two instances of `signal` not correctly being passed on through the middleware

cc @blacha 