### PR TITLE
fix: prevent reading invalid range on 206 responses

### DIFF
--- a/packages/source-http/src/__test__/source.http.test.ts
+++ b/packages/source-http/src/__test__/source.http.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import { after, afterEach, before, beforeEach, describe, it } from 'node:test';
 
 import type { FetchLikeOptions, FetchLikeResponse } from '../index.js';
-import { SourceHttp } from '../index.js';
+import { getMetadataFromResponse, SourceHttp } from '../index.js';
 
 export interface HttpHeaders {
   Range: string;
@@ -113,6 +113,24 @@ describe('SourceHttp', () => {
     it('should should support "../../../"', () => {
       const sourceRelUp = new SourceHttp('../../../bar.txt');
       assert.equal(sourceRelUp.url.href, 'https://example.com/bar.txt');
+    });
+  });
+
+  describe('getMetadataFromResponse', () => {
+    it('should not set metadata.size to chunk length on 206 response when content-range is missing', () => {
+      const headers = new Map<string, string>([['content-length', '1024']]);
+      const res: FetchLikeResponse = {
+        ok: true,
+        status: 206,
+        statusText: 'Partial Content',
+        headers: { get: (k: string) => headers.get(k) ?? null },
+        body: null,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(1024)),
+      };
+
+      const metadata = getMetadataFromResponse(res);
+      // In a 206 Partial Content response, content-length is ONLY the chunk payload size (1024).
+      assert.equal(metadata.size, undefined);
     });
   });
 });

--- a/packages/source-http/src/index.ts
+++ b/packages/source-http/src/index.ts
@@ -17,14 +17,16 @@ export interface FetchLikeResponse {
 }
 export type FetchLike = (url: string | URL, opts?: FetchLikeOptions) => Promise<FetchLikeResponse>;
 
-/** Load the ETag and content-range from the response */
 export function getMetadataFromResponse(response: FetchLikeResponse): SourceMetadata {
   const metadata: SourceMetadata = {};
-  const contentLength = response.headers.get('content-length');
-  if (contentLength) metadata.size = parseInt(contentLength);
 
   const contentRange = response.headers.get('content-range');
-  if (contentRange != null) metadata.size = ContentRange.parseSize(contentRange);
+  if (contentRange != null) {
+    metadata.size = ContentRange.parseSize(contentRange);
+  } else if (response.status !== 206) {
+    const contentLength = response.headers.get('content-length');
+    if (contentLength) metadata.size = parseInt(contentLength, 10);
+  }
 
   metadata.eTag = response.headers.get('etag') ?? undefined;
   metadata.contentType = response.headers.get('content-type') ?? undefined;

--- a/packages/source/src/__test__/range.test.ts
+++ b/packages/source/src/__test__/range.test.ts
@@ -17,5 +17,10 @@ describe('ContentRange', () => {
     assert.throws(() => ContentRange.parseSize(''));
     assert.throws(() => ContentRange.parseSize('test 1234'));
     assert.throws(() => ContentRange.parseSize('bytes 0-1024/*'));
+    assert.throws(() => ContentRange.parseSize('bytes 0-1024/'));
+  });
+
+  it('should throw on zero or negative range lengths', () => {
+    assert.throws(() => ContentRange.toRange(0, 0));
   });
 });

--- a/packages/source/src/range.ts
+++ b/packages/source/src/range.ts
@@ -18,7 +18,7 @@ export const ContentRange = {
    *
    * @example
    * ```typescript
-   * ContentRange.parseRange("bytes 200-1000/67589"); // 67589
+   * ContentRange.parseSize("bytes 200-1000/67589"); // 67589
    * ```
    * @throws if range is not a Content-Range with size
    */
@@ -27,8 +27,8 @@ export const ContentRange = {
     if (unit !== 'bytes') throw new Error('Failed to parse content-range: ' + range);
     if (chunks == null) throw new Error('Failed to parse content-range: ' + range);
     const [, size] = chunks.split('/');
-    const result = Number(size);
-    if (isNaN(result)) throw new Error('Failed to parse content-range: ' + range);
+    const result = Number.parseInt(size, 10);
+    if (Number.isNaN(result)) throw new Error('Failed to parse content-range: ' + range);
     return result;
   },
 };

--- a/packages/source/src/range.ts
+++ b/packages/source/src/range.ts
@@ -10,6 +10,7 @@ export const ContentRange = {
   toRange(offset: number, length?: number): string {
     if (length == null) return `bytes=${offset}`;
     if (offset < 0) throw new Error('Cannot read from remote source with negative offset and length');
+    if (length <= 0) throw new Error('Cannot read range with length <= 0');
     return `bytes=${offset}-${offset + length - 1}`;
   },
 


### PR DESCRIPTION
#### Motivation

With CORS sometimes blocking content-range headers, the metadata.size can sometimes be incorrectly set to a chunk length.

#### Modification

If the response is 206 partial content, never trust the content-length.
Fixed parsing invalid byte ranges to 0 size.

#### Verification

unit tests.


Fixes #1691
